### PR TITLE
Matched categories to reactions

### DIFF
--- a/extensions/help_channels/channel_manager.py
+++ b/extensions/help_channels/channel_manager.py
@@ -245,8 +245,8 @@ class ChannelManager(Injectable):
                 name="Categories",
                 value=(
                     (
-                        f"🐍 Python/Discord.py\n{js_emoji} JavaScript/Node.js/Deno\n🌵 C/C++/C#\n🌎 Web Dev/HTML/CSS\n"
-                        f"💾 OS/Docker/Kubernetes\n☕️ Java/Kotlin\n🙋 General Help"
+                        f"🐍 Python/Discord.py\n🌵 C/C++/C#\n🌎 Web Dev/HTML/CSS\n"
+                        f"💾 OS/Docker/Kubernetes\n☕️ Java/Kotlin\n{js_emoji} JavaScript/Node.js/Deno\n🙋 General Help"
                     )
                 ),
             )


### PR DESCRIPTION
Earlier `javascript` was positioned in the incorrect place, ie, after `python` and before `c/c++/c#` when according to the reactions below it should have been after `java/kotlin` and before `general help`. 

The code commited should potentially fix this [bug](https://discord.com/channels/644299523686006834/711633413945163896/942388943587008522)

