### PR TITLE
Add reaction emoji to remove own bot messages

### DIFF
--- a/beginner/cogs/code_runner.py
+++ b/beginner/cogs/code_runner.py
@@ -127,6 +127,7 @@ class CodeRunner(Cog):
             reaction.emoji.name in self._delete_emojis
             and reaction.member in message.mentions
             and message.author == self.client.user
+            and "Exception Raised" in message.embeds[0].title
         ):
             await message.delete()
 

--- a/beginner/cogs/code_runner.py
+++ b/beginner/cogs/code_runner.py
@@ -123,9 +123,12 @@ class CodeRunner(Cog):
         elif reaction.emoji.name in self._formatting_emojis:
             await self._black_formatting(message, message.content, reaction.member)
 
-        elif reaction.emoji.name in self._delete_emojis and reaction.member in message.mentions:
+        elif (
+            reaction.emoji.name in self._delete_emojis
+            and reaction.member in message.mentions
+            and message.author == self.client.user
+        ):
             await message.delete()
-
 
     async def _exec(
         self,

--- a/beginner/cogs/code_runner.py
+++ b/beginner/cogs/code_runner.py
@@ -19,6 +19,7 @@ class CodeRunner(Cog):
         self._exec_rate_limit = {}
         self._code_runner_emojis = "▶️⏯"
         self._formatting_emojis = "✏️📝"
+        self._delete_emojis = "🗑️"
 
     @Cog.command()
     async def dis(self, ctx, *, content=""):
@@ -96,7 +97,7 @@ class CodeRunner(Cog):
     async def on_raw_reaction_add(self, reaction: nextcord.RawReactionActionEvent):
         if (
             reaction.emoji.name
-            not in self._code_runner_emojis + self._formatting_emojis
+            not in self._code_runner_emojis + self._formatting_emojis + self._delete_emojis
         ):
             return
 
@@ -121,6 +122,10 @@ class CodeRunner(Cog):
 
         elif reaction.emoji.name in self._formatting_emojis:
             await self._black_formatting(message, message.content, reaction.member)
+
+        elif reaction.emoji.name in self._delete_emojis and reaction.member in message.mentions:
+            await message.delete()
+
 
     async def _exec(
         self,


### PR DESCRIPTION
Allows bot messages to be removed by the member mentioned by the bot message. 
The intention is that this will allow people to clean up incorrect `exec` and `eval` commands.

Checks for `Member in Message.mentions` so shouldn't have any unintended side effects such as allowing anybody with a certain role mentioned by the bot to delete messages.