### PR TITLE
Add buddy chat functionality

### DIFF
--- a/beginner/cog.py
+++ b/beginner/cog.py
@@ -4,11 +4,10 @@ from beginner.logging import get_logger
 from beginner.settings import Settings
 from beginner.tags import TaggableMeta
 from nextcord.ext import commands
-from nextcord import TextChannel, Client, Guild, Emoji, CategoryChannel, Role
+from nextcord import TextChannel, Client, Guild, Emoji, CategoryChannel, Role, slash_command
 from typing import Any, AnyStr, Coroutine, List, Optional
 import json
 import os.path
-
 
 class Cog(commands.Cog, metaclass=TaggableMeta):
     def __init__(self, client: Client):
@@ -80,6 +79,11 @@ class Cog(commands.Cog, metaclass=TaggableMeta):
     @staticmethod
     def group(*args, **kwargs) -> commands.Group:
         return commands.group(*args, **kwargs)
+
+    @staticmethod
+    def slash_command(*args, **kwargs) -> slash_command:
+        return slash_command(*args, **kwargs)
+
 
 
 class AdvancedCommand:

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -1,0 +1,37 @@
+from beginner.cogs.settings import Settings
+import nextcord
+from nextcord.ext import commands
+
+from beginner.cog import Cog
+from beginner.models.settings import Settings
+
+
+class BuddyCog(Cog):
+    def __init__(self, client):
+        super().__init__(client)
+
+    @Cog.command("set-buddychat-category")
+    @commands.has_permissions(kick_members=True)
+    async def set_buddy_chat_category_command(
+        self, ctx: nextcord.ext.commands.Context, category: nextcord.CategoryChannel
+    ):
+        if not category:
+            await ctx.send(f"Couldn't find a category named {category!r}.")
+            return
+    
+        await self.set_buddy_chat_category(category)
+
+        await ctx.send(
+            f"Set {category} as the buddy chat category."
+        )
+
+    async def set_buddy_chat_category(self, category: nextcord.CategoryChannel):
+        buddy_category = Settings(
+            name="BUDDY_CATEGORY",
+            value=category,
+        )
+        buddy_category.save()
+
+
+def setup(client):
+    client.add_cog(BuddyCog(client))

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -1,3 +1,4 @@
+from unicodedata import category
 import nextcord
 from nextcord.ext import commands
 
@@ -6,15 +7,6 @@ from beginner.models.settings import Settings
 
 
 class BuddyCog(Cog):
-#    def __init__(self, client):
-#        super().__init__(client)
-
-    @Cog.listener()
-    async def on_ready(self):
-        category = await self.get_buddy_chat_category()
-        print(type(category))
-        print(category)
-
 
     @Cog.command("set-buddychat-category")
     @commands.has_permissions(kick_members=True)
@@ -108,6 +100,33 @@ class BuddyCog(Cog):
             return
         
         await ctx.channel.edit(name=name)
+
+    
+    @Cog.command("close")
+    @commands.has_permissions(kick_members=True)
+    async def close_buddy_chat(self, ctx: nextcord.ext.commands.Context):
+        category = await self.get_buddy_chat_category()
+
+        if not category or ctx.channel.category.name != category:
+            return
+
+        await ctx.channel.delete()
+
+
+    @Cog.command("archive")
+    @commands.has_permissions(kick_members=True)
+    async def archive_buddy_chat(self, ctx: nextcord.ext.commands.Context):
+        category = await self.get_buddy_chat_category()
+
+        if not category or ctx.channel.category.name != category:
+            return
+
+        members = await ctx.channel.fetch_members()
+        for member in members:
+            await ctx.channel.remove_user(member)
+
+        await ctx.channel.edit(name=f"{ctx.channel.name}-archive")
+        await ctx.channel.send("🗂 This channel has been archived")
 
 
 def setup(client):

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -1,4 +1,3 @@
-from unicodedata import category
 import nextcord
 from nextcord.ext import commands
 

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -75,18 +75,24 @@ class BuddyCog(Cog):
 
         if not category or ctx.channel.category.name != category:
             return
+
+        if not isinstance(ctx.channel, nextcord.Thread):
+            return
         
         await ctx.channel.remove_user(member)
 
 
     @Cog.command("add")
     @commands.has_permissions(kick_members=True)
-    async def remove_buddy(self, ctx: nextcord.ext.commands.Context, member: nextcord.Member):
+    async def add_buddy(self, ctx: nextcord.ext.commands.Context, member: nextcord.Member):
         category = await self.get_buddy_chat_category()
 
         if not category or ctx.channel.category.name != category:
             return
-        
+
+        if not isinstance(ctx.channel, nextcord.Thread):
+            return
+
         await ctx.channel.add_user(member)
 
 
@@ -96,6 +102,9 @@ class BuddyCog(Cog):
         category = await self.get_buddy_chat_category()
 
         if not category or ctx.channel.category.name != category:
+            return
+
+        if not isinstance(ctx.channel, nextcord.Thread):
             return
         
         await ctx.channel.edit(name=name)
@@ -109,6 +118,9 @@ class BuddyCog(Cog):
         if not category or ctx.channel.category.name != category:
             return
 
+        if not isinstance(ctx.channel, nextcord.Thread):
+            return
+
         await ctx.channel.delete()
 
 
@@ -118,6 +130,9 @@ class BuddyCog(Cog):
         category = await self.get_buddy_chat_category()
 
         if not category or ctx.channel.category.name != category:
+            return
+
+        if not isinstance(ctx.channel, nextcord.Thread):
             return
 
         members = await ctx.channel.fetch_members()

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -102,5 +102,16 @@ class BuddyCog(Cog):
         await ctx.channel.add_user(member)
 
 
+    @Cog.command("rename")
+    @commands.has_permissions(kick_members=True)
+    async def rename_buddy_chat(self, ctx: nextcord.ext.commands.Context, *, name: str):
+        category = await self.get_buddy_chat_category()
+
+        if not category or ctx.channel.category.name != category:
+            return
+        
+        await ctx.channel.edit(name=name)
+
+
 def setup(client):
     client.add_cog(BuddyCog(client))

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -1,3 +1,4 @@
+from unicodedata import category
 from discord import Member
 from beginner.cogs.settings import Settings
 import nextcord
@@ -50,7 +51,7 @@ class BuddyCog(Cog):
     async def create_buddy_chat(self, ctx: nextcord.ext.commands.Context, name: str, members: commands.Greedy[nextcord.Member]):
         category = await self.get_buddy_chat_category()
 
-        if not category or ctx.channel.category == category:
+        if not category or ctx.channel.category.name != category:
             return
 
         thread = await ctx.channel.create_thread(name=name)
@@ -77,6 +78,28 @@ class BuddyCog(Cog):
             )
         )
         await welcome_msg.pin()
+    
+
+    @Cog.command("remove")
+    @commands.has_permissions(kick_members=True)
+    async def remove_buddy(self, ctx: nextcord.ext.commands.Context, member: nextcord.Member):
+        category = await self.get_buddy_chat_category()
+
+        if not category or ctx.channel.category.name != category:
+            return
+        
+        await ctx.channel.remove_user(member)
+
+
+    @Cog.command("add")
+    @commands.has_permissions(kick_members=True)
+    async def remove_buddy(self, ctx: nextcord.ext.commands.Context, member: nextcord.Member):
+        category = await self.get_buddy_chat_category()
+
+        if not category or ctx.channel.category.name != category:
+            return
+        
+        await ctx.channel.add_user(member)
 
 
 def setup(client):

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -1,3 +1,4 @@
+from discord import Member
 from beginner.cogs.settings import Settings
 import nextcord
 from nextcord.ext import commands
@@ -7,8 +8,15 @@ from beginner.models.settings import Settings
 
 
 class BuddyCog(Cog):
-    def __init__(self, client):
-        super().__init__(client)
+#    def __init__(self, client):
+#        super().__init__(client)
+
+    @Cog.listener()
+    async def on_ready(self):
+        category = await self.get_buddy_chat_category()
+        print(type(category))
+        print(category)
+
 
     @Cog.command("set-buddychat-category")
     @commands.has_permissions(kick_members=True)
@@ -31,6 +39,44 @@ class BuddyCog(Cog):
             value=category,
         )
         buddy_category.save()
+
+    async def get_buddy_chat_category(self) -> str:
+        category = Settings.select().where(Settings.name == "BUDDY_CATEGORY").get()
+        return category.value
+
+
+    @Cog.command("buddy")
+    @commands.has_permissions(kick_members=True)
+    async def create_buddy_chat(self, ctx: nextcord.ext.commands.Context, name: str, members: commands.Greedy[nextcord.Member]):
+        category = await self.get_buddy_chat_category()
+
+        if not category or ctx.channel.category == category:
+            return
+
+        thread = await ctx.channel.create_thread(name=name)
+        for member in members:
+            await thread.add_user(member)
+
+        welcome_msg = await thread.send(
+            embed=nextcord.Embed(
+                title=f"Welcome to your buddy chat!",
+                description=(
+                    "**Recommended Structure**\n"
+                    "**Daily**\n"
+                    "Check in, talk about what you've been working on and any struggles.\n"
+                    "**Weekly**\n"
+                    "Set goals for the week, review them. Have you achieved your goals? If not, why not?\n"
+                    "\n"
+                    "**Goal Ideas**\n"
+                    "- Start a new project.\n"
+                    "- Start learning a new language.\n"
+                    "- Implemenent a new feature in your project.\n"
+                    "- Spent at least two hours a day programming.\n"
+                ),
+                color=0x00FF66
+            )
+        )
+        await welcome_msg.pin()
 
 
 def setup(client):

--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -1,6 +1,3 @@
-from unicodedata import category
-from discord import Member
-from beginner.cogs.settings import Settings
 import nextcord
 from nextcord.ext import commands
 

--- a/production.yaml
+++ b/production.yaml
@@ -9,6 +9,7 @@ cogs:
   beginner_cog:
     enabled: true
     from: beginner.beginner
+  buddy: true
   bump: true
   candidates: true
   challenges: true


### PR DESCRIPTION
Add buddy chat functionality utilising Private Threads

Commands:
`!set-buddychat-category <category-name>`
Set the category to be used for buddy chat

`!buddy <thread_name> <mention1> <mention2>...`
Create a private thread with the name `thread_name` and add the mentioned users

`!remove <mention>`
To be used in the thread. Remove a member from a thread.

`!add <mention>`
To be used in the thread. Add a member to a thread.

`!remove <mention>`
To be used in the thread. Removes a member from a thread.

`!rename <name>`
To be used in a thread. Renames a thread to `name`

`!close`
To be used in a thread. Deletes a thread.

`!archive`
To be used in a thread. Removes all members and appends `-archive` to the thread name.

@bobbyinvents has an awesome idea for the form that users submit with information. The above adds most of the channel functionality.

At the moment a lot of this requires mod intervention but if the feature gains traction it would be nice to add an automated way for people to create their own buddy chats but this would need work to prevent abuse. Such as thread names (even though they are't public) and rate limiting the number of threads people can create.

Side Note: I've also tweaked the `Cog` class to allow slash commands for Bobby's feature.