### PR TITLE
Fix order of min and max age in age range

### DIFF
--- a/beginner/cogs/buddy.py
+++ b/beginner/cogs/buddy.py
@@ -266,7 +266,7 @@ class LookForBuddy(nextcord.ui.Modal):
         if self.age_range.values:
             embed.add_field(
                 name="Age Range:",
-                value="-".join(i for i in self.age_range.values)
+                value="-".join(i for i in sorted(self.age_range.values))
                 if len(self.age_range.values) > 1
                 else self.age_range.values[0],
                 inline=True,


### PR DESCRIPTION
If a user interacts with the /looking-for-buddy modal and selects a higher number first before the lower number for the age range, the embed will output "Age Range: 33-30".

This change will sort the list so that the lower number is always first.