### PR TITLE
Add more informative file upload messages and colors

### DIFF
--- a/beginner/cogs/spam.py
+++ b/beginner/cogs/spam.py
@@ -178,7 +178,6 @@ class SpamCog(Cog):
             )
 
         if disallowed:
-            embed.colour = RED
             embed.add_field(
                 name="Ignored these files due to them having unallowed file extensions",
                 value="\n".join(f"- {attachment.filename}" for attachment in disallowed)

--- a/beginner/cogs/spam.py
+++ b/beginner/cogs/spam.py
@@ -112,7 +112,7 @@ class SpamCog(Cog):
         )
         embed = Embed(
             title="File Attachments Not Allowed",
-            description=f"For safety reasons we do not allow files with certain file extensions and video attachments.",
+            description=f"For safety reasons we do not allow files with certain file extensions.",
             color=RED,
         )
 

--- a/beginner/cogs/spam.py
+++ b/beginner/cogs/spam.py
@@ -112,13 +112,14 @@ class SpamCog(Cog):
         )
         embed = Embed(
             title="File Attachments Not Allowed",
-            description=f"For safety reasons we do not allow file and video attachments.",
-            color=YELLOW,
+            description=f"For safety reasons we do not allow files with certain file extensions and video attachments.",
+            color=RED,
         )
 
         if allowed:
-            embed.title = f"{message.author.display_name} Uploaded Some Code"
+            embed.title = f"{message.author.display_name} Successfully Uploaded Some Code"
             embed.description = user_message
+            embed.colour = GREEN
             files = {}
             for attachment in allowed:
                 content = (await attachment.read()).decode()
@@ -153,7 +154,7 @@ class SpamCog(Cog):
             )
 
             embed.set_footer(
-                text="For safety reasons we do not allow file attachments."
+                text="For safety reasons we upload approved file extension files to a Gist."
             )
 
         else:
@@ -177,8 +178,9 @@ class SpamCog(Cog):
             )
 
         if disallowed:
+            embed.colour = RED
             embed.add_field(
-                name="Ignored these files",
+                name="Ignored these files due to them having unallowed file extensions",
                 value="\n".join(f"- {attachment.filename}" for attachment in disallowed)
                 or "*NO FILES*",
             )


### PR DESCRIPTION
It seemed like a lot of members were confused when a file gets uploaded to a Gist due to unintuitive color codes and potentially misleading information.

I tried using the following colors for the following scenarios

- GREEN for when all files were successfully uploaded,
- and RED for uploads where no files were uploaded

I also tried making the embed give more information about why the files get uploaded to a Gist or why their files were not accepted.