### PR TITLE
Add resources for asking good questions & fix !r command formatting

### DIFF
--- a/beginner/cogs/resources.py
+++ b/beginner/cogs/resources.py
@@ -13,7 +13,7 @@ class ResourcesCog(Cog):
             embed = nextcord.Embed(
                 title="Helpful Resources",
                 description=(
-                    f"{ctx.author.mention} here are all the topics we currently have resources for."
+                    f"{ctx.author.mention} here are all the topics we currently have resources for. "
                     f"Use the `{ctx.prefix}resources <topic>` command to get resources for a specific topic."
                 ),
                 color=YELLOW,

--- a/production.yaml
+++ b/production.yaml
@@ -258,6 +258,16 @@ resources:
       TAILS: https://tails.boum.org/
       Qubes OS: https://www.qubes-os.org/
       Whonix: https://www.whonix.org/
+  
+  questions:
+    name: Questions & how to ask good ones
+    Recommended Reading:
+      Asking Good Technical Questions: https://www.freecodecamp.org/news/how-to-ask-good-technical-questions/
+      XY Problem: https://xyproblem.info/
+      Dont Ask To Ask, Just Ask: https://dontasktoask.com/
+      Short, Self Contained, Correct (Compilable), Example: http://sscce.org/
+      How to create a Minimal, Reproducible Example: https://stackoverflow.com/help/minimal-reproducible-example
+      
 
 lang_aliases:
   py: python


### PR DESCRIPTION
Add various resources for asking good questions.

Fix !r response appearing on discord like:
`here are all the topics we currently have resources for.Use the !resources <topic> command to get resources for a specific topic.`. We want a space afterwards, so the two sentences are separated, and fix so it should appear with a space after first/second sentence like `here are all the topics we currently have resources for. Use the !resources <topic> command to get resources for a specific topic.`.