### PR TITLE
Update Recommended Code Hosts

### DIFF
--- a/beginner/cogs/challenges.py
+++ b/beginner/cogs/challenges.py
@@ -46,7 +46,6 @@ class Challenges(Cog):
         self.challenge_reminder_added = False
         self.approved_hosts = [
             "gist.github.com",
-            "hastebin.com",
             "pastebin.com",
             "github.com",
         ]

--- a/beginner/cogs/challenges.py
+++ b/beginner/cogs/challenges.py
@@ -46,7 +46,6 @@ class Challenges(Cog):
         self.challenge_reminder_added = False
         self.approved_hosts = [
             "gist.github.com",
-            "paste.pythonnextcord.com",
             "hastebin.com",
             "pastebin.com",
             "github.com",

--- a/beginner/cogs/spam.py
+++ b/beginner/cogs/spam.py
@@ -126,7 +126,7 @@ class SpamCog(Cog):
         )
         embed.add_field(
             name="Large Portions of Code",
-            value=f"For longer scripts use [Hastebin](https://hastebin.com/) or "
+            value=f"For longer scripts use a code hosting platform like "
             f"[GitHub Gists](https://gist.github.com/) and share the link here",
             inline=False,
         )


### PR DESCRIPTION
Hastebin has been acquired by a company and so may not be trustworthy enough to recommend people to use. Additionally, paste.pythonnextcord.com seems to not exist anymore.